### PR TITLE
Refactor onsite gap week logic to clamp exceptions within date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The overall goal is to replace manual schedule exception entry with consistent, 
 
 4. **Onsite Logic (Optional)**
    - If an onsite period is detected (< 30 days and within the schedule range):
-     - A full Monday–Sunday onsite gap week is reserved.
+   - A Monday–Sunday onsite gap week is calculated.
+   - The generated onsite gap exception is clamped to the input schedule range.
      - The gap week receives a zero-hour schedule exception.
      - All category allocations exclude the onsite gap.
      - The Post category is created only when onsite is valid.
@@ -145,7 +146,8 @@ Onsite is considered valid only if:
 - Fully contained within the schedule range
 
 ### Onsite Gap Week
-- A full **Monday–Sunday onsite gap week** is reserved
+- A **Monday–Sunday onsite gap week** is calculated
+- The generated onsite gap exception is **clamped to the input schedule window** (`startDate` to `endDate`)
 - The gap week generates a **zero-hour schedule exception**
 - All category allocations **exclude onsite gap days**
 - The **Post** category begins **after the onsite gap week ends**
@@ -204,5 +206,6 @@ The test class `ScheduleHoursDistributorTest` provides comprehensive coverage fo
 | `testAllCategoriesInvalid_NoCrash` | Zero-week categories produce no exceptions without throwing an error |
 | `testGenerateScheduleExceptions_MultipleValidInputs` | Batch processing of two valid inputs returns two wrappers |
 | `testGenerateScheduleExceptions_MixedValidAndInvalidInputs` | Batch processing of valid + invalid input returns one success and one error |
+| `testOnsiteGapClampedToInputDateRange` | Onsite gap exception and all generated exceptions remain within input start/end boundaries |
 | `testGenerateScheduleExceptions_TwoValidInputs_NoErrors` | Two valid inputs both return wrappers with no errors |
 

--- a/force-app/main/default/classes/ScheduleHoursDistributor.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributor.cls
@@ -149,10 +149,14 @@ public with sharing class ScheduleHoursDistributor {
         excludeDates.addAll(holidayDates);
 
         if (onsiteNeeded && onsiteGapWeekStart != null && onsiteGapWeekEnd != null) {
-            addSplitExceptions(
-                onsiteGapWeekStart, onsiteGapWeekEnd, 0, input.numberOfWorkDays, input.scheduleId,
-                input.startDate, input.endDate, holidayDates, allExceptions, new List<pse__Schedule_Exception__c>()
-            );
+            Date onsiteSegmentStart = (onsiteGapWeekStart < input.startDate) ? input.startDate : onsiteGapWeekStart;
+            Date onsiteSegmentEnd = (onsiteGapWeekEnd > input.endDate) ? input.endDate : onsiteGapWeekEnd;
+            if (onsiteSegmentStart <= onsiteSegmentEnd) {
+                addSplitExceptions(
+                    onsiteSegmentStart, onsiteSegmentEnd, 0, input.numberOfWorkDays, input.scheduleId,
+                    input.startDate, input.endDate, holidayDates, allExceptions, new List<pse__Schedule_Exception__c>()
+                );
+            }
         }
 
         Set<Date> allSplits = new Set<Date>();

--- a/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
@@ -572,6 +572,101 @@ public class ScheduleHoursDistributorTest {
     }
 
     @isTest
+    static void testOnsiteGapClampedToInputDateRange() {
+        pse__Schedule__c schedule = new pse__Schedule__c(
+            pse__Start_Date__c = Date.newInstance(2026, 6, 1),
+            pse__End_Date__c = Date.newInstance(2026, 10, 10),
+            pse__Scheduled_Hours__c = 20,
+            pse__Monday_Hours__c = 8,
+            pse__Tuesday_Hours__c = 8,
+            pse__Wednesday_Hours__c = 8,
+            pse__Thursday_Hours__c = 8,
+            pse__Friday_Hours__c = 8,
+            pse__Saturday_Hours__c = 0,
+            pse__Sunday_Hours__c = 0
+        );
+        insert schedule;
+
+        List<pse__Schedule_Exception__c> holidays = new List<pse__Schedule_Exception__c>{
+            new pse__Schedule_Exception__c(
+                pse__Schedule__c = schedule.Id,
+                pse__Date__c = Date.newInstance(2026, 6, 19),
+                pse__End_Date__c = Date.newInstance(2026, 6, 19),
+                pse__Monday_Hours__c = 0, pse__Tuesday_Hours__c = 0, pse__Wednesday_Hours__c = 0, pse__Thursday_Hours__c = 0, pse__Friday_Hours__c = 0, pse__Saturday_Hours__c = 0, pse__Sunday_Hours__c = 0
+            ),
+            new pse__Schedule_Exception__c(
+                pse__Schedule__c = schedule.Id,
+                pse__Date__c = Date.newInstance(2026, 7, 2),
+                pse__End_Date__c = Date.newInstance(2026, 7, 2),
+                pse__Monday_Hours__c = 0, pse__Tuesday_Hours__c = 0, pse__Wednesday_Hours__c = 0, pse__Thursday_Hours__c = 0, pse__Friday_Hours__c = 0, pse__Saturday_Hours__c = 0, pse__Sunday_Hours__c = 0
+            ),
+            new pse__Schedule_Exception__c(
+                pse__Schedule__c = schedule.Id,
+                pse__Date__c = Date.newInstance(2026, 7, 3),
+                pse__End_Date__c = Date.newInstance(2026, 7, 3),
+                pse__Monday_Hours__c = 0, pse__Tuesday_Hours__c = 0, pse__Wednesday_Hours__c = 0, pse__Thursday_Hours__c = 0, pse__Friday_Hours__c = 0, pse__Saturday_Hours__c = 0, pse__Sunday_Hours__c = 0
+            ),
+            new pse__Schedule_Exception__c(
+                pse__Schedule__c = schedule.Id,
+                pse__Date__c = Date.newInstance(2026, 9, 4),
+                pse__End_Date__c = Date.newInstance(2026, 9, 4),
+                pse__Monday_Hours__c = 0, pse__Tuesday_Hours__c = 0, pse__Wednesday_Hours__c = 0, pse__Thursday_Hours__c = 0, pse__Friday_Hours__c = 0, pse__Saturday_Hours__c = 0, pse__Sunday_Hours__c = 0
+            ),
+            new pse__Schedule_Exception__c(
+                pse__Schedule__c = schedule.Id,
+                pse__Date__c = Date.newInstance(2026, 9, 7),
+                pse__End_Date__c = Date.newInstance(2026, 9, 7),
+                pse__Monday_Hours__c = 0, pse__Tuesday_Hours__c = 0, pse__Wednesday_Hours__c = 0, pse__Thursday_Hours__c = 0, pse__Friday_Hours__c = 0, pse__Saturday_Hours__c = 0, pse__Sunday_Hours__c = 0
+            )
+        };
+
+        ScheduleHoursDistributor.ScheduleInput input = new ScheduleHoursDistributor.ScheduleInput();
+        input.scheduleId = schedule.Id;
+        input.startDate = Date.newInstance(2026, 6, 1);
+        input.endDate = Date.newInstance(2026, 10, 10);
+        input.numberOfHours = 20;
+        input.numberOfWorkDays = 5;
+        input.cat1Weeks = 10;
+        input.cat2Weeks = 4;
+        input.cat3Weeks = 6;
+        input.postWeeks = 6;
+        input.cat1Percentage = 20;
+        input.cat2Percentage = 20;
+        input.cat3Percentage = 50;
+        input.postPercentage = 10;
+        input.onsiteStartDate = Date.newInstance(2026, 10, 5);
+        input.onsiteEndDate = Date.newInstance(2026, 10, 8);
+        input.existingExceptions = holidays;
+
+        List<ScheduleHoursDistributor.ScheduleExceptionOutputWrapper> result =
+            ScheduleHoursDistributor.generateCategoryScheduleExceptions(
+                new List<ScheduleHoursDistributor.ScheduleInput>{ input }
+            );
+
+        System.assertEquals(1, result.size(), 'Should return one result');
+        System.assertEquals(null, result[0].errorMessage, 'Should not return an error');
+
+        for (pse__Schedule_Exception__c exc : result[0].scheduleExceptions) {
+            Date excStart = exc.pse__Date__c;
+            Date excEnd = (exc.pse__End_Date__c == null) ? excStart : exc.pse__End_Date__c;
+            System.assert(excStart >= input.startDate, 'Generated exception starts before the input start date');
+            System.assert(excEnd <= input.endDate, 'Generated exception ends after the input end date');
+        }
+
+        Boolean foundOnsiteGap = false;
+        for (pse__Schedule_Exception__c exc : result[0].scheduleExceptions) {
+            if (exc.pse__Date__c == Date.newInstance(2026, 10, 5)) {
+                Date excEnd = (exc.pse__End_Date__c == null) ? exc.pse__Date__c : exc.pse__End_Date__c;
+                if (excEnd == Date.newInstance(2026, 10, 10)) {
+                    foundOnsiteGap = true;
+                    break;
+                }
+            }
+        }
+        System.assertEquals(true, foundOnsiteGap, 'Onsite gap should be clamped to end on 2026-10-10');
+    }
+
+    @isTest
     static void testGenerateScheduleExceptions_TwoValidInputs_NoErrors() {
         // Use the two schedules from test setup
         List<pse__Schedule__c> schedules = [SELECT Id, pse__Start_Date__c, pse__End_Date__c, pse__Scheduled_Hours__c FROM pse__Schedule__c ORDER BY Id LIMIT 2];


### PR DESCRIPTION
Refactor the onsite gap week logic to ensure that exceptions are clamped within the specified input date range. Update tests to validate this behavior.

Fixes #54