### PR TITLE
Enhance countUsableWorkdays method with configurable workday patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ The overall goal is to replace manual schedule exception entry with consistent, 
    - Any unused or excess percentage is redistributed evenly.
 
 7. **Hour Distribution**
-   - Usable weekdays (Mon–Fri) are counted per category.
+   - Usable days are counted per category using `numberOfWorkDays`.
+   - Workday patterns are: `1 = Mon`, `5 = Mon–Fri`, `6 = Mon–Sat`, `7 = Mon–Sun`.
    - Holidays and onsite gap days are excluded.
    - Daily hours are calculated based on category percentage and usable days.
 
@@ -130,10 +131,11 @@ The method returns one wrapper per input containing:
 
 ## Hour Allocation Rules
 
-- Hours are assigned only to **weekdays (Monday–Friday)**
+- Hours are assigned to the first `numberOfWorkDays` days of each week (for example: `5 = Mon–Fri`, `7 = Mon–Sun`)
+- Usable-day counting uses the same `numberOfWorkDays` pattern as hour assignment
 - Holidays and onsite gap days are **always excluded**
 - Category percentages are **normalized** so valid categories total **100%**
-- Daily hours are calculated using **usable workdays only**
+- Daily hours are calculated using usable workdays only
 - A **rounding correction** is applied to the last generated exception to ensure the total assigned hours exactly match `numberOfHours`
 
 ---
@@ -167,8 +169,14 @@ Creates and returns a single `pse__Schedule_Exception__c` record with per-day ho
 ### `addSplitExceptions(Date segStart, Date segEnd, Decimal hoursPerDay, Integer workDays, Id scheduleId, Date inputStart, Date inputEnd, Set<Date> allSplits, List<pse__Schedule_Exception__c> allExceptions, List<pse__Schedule_Exception__c> catList)`
 Iterates a date range and splits it into contiguous segments at every holiday and onsite gap date. Each uninterrupted segment is created as a separate `pse__Schedule_Exception__c` record added to both `allExceptions` and `catList`.
 
+### `countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates, Integer numberOfWorkDays)`
+Counts usable days between two dates based on `numberOfWorkDays` (1-7), excluding any dates in `excludeDates` (holidays and onsite gap days).
+
 ### `countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates)`
-Counts the number of weekdays (Mon–Fri) between two dates, excluding any dates in `excludeDates` (holidays and onsite gap days).
+Backward-compatible overload that defaults to `5` (Mon–Fri).
+
+### `isScheduledWorkday(Date d, Integer numberOfWorkDays)`
+Returns `true` when a date falls within the configured weekly work pattern (`1 = Mon` through `7 = Mon–Sun`).
 
 ### `isWeekday(Date d)`
 Returns `true` if the given date falls on Monday through Friday.
@@ -202,7 +210,7 @@ The test class `ScheduleHoursDistributorTest` provides comprehensive coverage fo
 | `testMathWithExistingHolidayExcludesDate_TotalHoursMatch` | Holiday dates are excluded and total hours still match |
 | `testExtractHolidayDates_NullAndRanges` | `extractHolidayDates` handles null entries, single-day, and multi-day exceptions |
 | `testAddSplitExceptions_SplittingBehavior` | `addSplitExceptions` correctly splits segments at split dates |
-| `testCountUsableWorkdays_VariousRanges` | `countUsableWorkdays` counts correctly with weekends and excluded dates |
+| `testCountUsableWorkdays_VariousRanges` | `countUsableWorkdays` counts correctly for 3-day, 6-day, and 7-day schedules, including exclusions |
 | `testAllCategoriesInvalid_NoCrash` | Zero-week categories produce no exceptions without throwing an error |
 | `testGenerateScheduleExceptions_MultipleValidInputs` | Batch processing of two valid inputs returns two wrappers |
 | `testGenerateScheduleExceptions_MixedValidAndInvalidInputs` | Batch processing of valid + invalid input returns one success and one error |

--- a/force-app/main/default/classes/ScheduleHoursDistributor.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributor.cls
@@ -171,13 +171,13 @@ public with sharing class ScheduleHoursDistributor {
         };
 
         Integer cat1UsableDays = (cat1Valid && cat1ActualStart != null && cat1ActualEnd != null && cat1ActualStart <= cat1ActualEnd)
-            ? countUsableWorkdays(cat1ActualStart, cat1ActualEnd, allSplits) : 0;
+            ? countUsableWorkdays(cat1ActualStart, cat1ActualEnd, allSplits, input.numberOfWorkDays) : 0;
         Integer cat2UsableDays = (cat2Valid && cat2ActualStart != null && cat2ActualEnd != null && cat2ActualStart <= cat2ActualEnd)
-            ? countUsableWorkdays(cat2ActualStart, cat2ActualEnd, allSplits) : 0;
+            ? countUsableWorkdays(cat2ActualStart, cat2ActualEnd, allSplits, input.numberOfWorkDays) : 0;
         Integer cat3UsableDays = (cat3Valid && cat3ActualStart != null && cat3ActualEnd != null && cat3ActualStart <= cat3ActualEnd)
-            ? countUsableWorkdays(cat3ActualStart, cat3ActualEnd, allSplits) : 0;
+            ? countUsableWorkdays(cat3ActualStart, cat3ActualEnd, allSplits, input.numberOfWorkDays) : 0;
         Integer postUsableDays = (postValid && postActualStart != null && postActualEnd != null && postActualStart <= postActualEnd)
-            ? countUsableWorkdays(postActualStart, postActualEnd, allSplits) : 0;
+            ? countUsableWorkdays(postActualStart, postActualEnd, allSplits, input.numberOfWorkDays) : 0;
 
         Map<String, Decimal> hoursPerDayMap = new Map<String, Decimal>{'cat1' => 0, 'cat2' => 0, 'cat3' => 0, 'post' => 0};
         List<String> usableCats = new List<String>();
@@ -348,23 +348,42 @@ public with sharing class ScheduleHoursDistributor {
         }
     }
 
-    // Helper: Counts usable workdays (Mon-Fri) between two dates, excluding holidays and onsite gap days
-    public static Integer countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates) {
+    // Helper: Counts usable workdays between two dates, excluding holidays and onsite gap days.
+    // Workday pattern follows numberOfWorkDays: 1=Mon only ... 5=Mon-Fri, 6=Mon-Sat, 7=Mon-Sun.
+    public static Integer countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates, Integer numberOfWorkDays) {
+        Integer boundedWorkDays = numberOfWorkDays == null ? 5 : numberOfWorkDays;
+        if (boundedWorkDays < 1) boundedWorkDays = 1;
+        if (boundedWorkDays > 7) boundedWorkDays = 7;
+
         Integer count = 0;
         for (Date d = start; d <= endDate; d = d.addDays(1)) {
-            Boolean weekday = isWeekday(d);
+            Boolean scheduledWorkday = isScheduledWorkday(d, boundedWorkDays);
             Boolean excluded = excludeDates.contains(d);
-            if (weekday && !excluded) {
+            if (scheduledWorkday && !excluded) {
                 count++;
             }
             if (DEBUG) {
-                System.debug('countUsableWorkdays: date=' + d + ', isWeekday=' + weekday + ', isExcluded=' + excluded + ', runningCount=' + count);
+                System.debug('countUsableWorkdays: date=' + d + ', isScheduledWorkday=' + scheduledWorkday + ', isExcluded=' + excluded + ', runningCount=' + count + ', numberOfWorkDays=' + boundedWorkDays);
             }
         }
         if (DEBUG) {
-            System.debug('countUsableWorkdays: FINAL count for range ' + start + ' to ' + endDate + ' (excludes=' + excludeDates + ') = ' + count);
+            System.debug('countUsableWorkdays: FINAL count for range ' + start + ' to ' + endDate + ' (excludes=' + excludeDates + ', numberOfWorkDays=' + boundedWorkDays + ') = ' + count);
         }
         return count;
+    }
+
+    // Backward-compatible overload defaults to Mon-Fri behavior.
+    public static Integer countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates) {
+        return countUsableWorkdays(start, endDate, excludeDates, 5);
+    }
+
+    // Helper: Returns true if date is one of the configured workdays for the week.
+    public static Boolean isScheduledWorkday(Date d, Integer numberOfWorkDays) {
+        Integer boundedWorkDays = numberOfWorkDays == null ? 5 : numberOfWorkDays;
+        if (boundedWorkDays < 1) boundedWorkDays = 1;
+        if (boundedWorkDays > 7) boundedWorkDays = 7;
+        Integer dow = d.toStartOfWeek().daysBetween(d) + 1; // 1=Monday, 7=Sunday
+        return dow >= 1 && dow <= boundedWorkDays;
     }
 
     // Helper: Returns true if the date is a weekday (Mon-Fri)

--- a/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
@@ -476,6 +476,25 @@ public class ScheduleHoursDistributorTest {
             if (ScheduleHoursDistributor.isWeekday(d) && !exclAll.contains(d)) expected++;
         }
         System.assertEquals(expected, cnt);
+
+        // Explicit workday patterns: 6-day should include Saturday, exclude Sunday
+        Date cStart = Date.newInstance(2025,1,6); // Monday
+        Date cEnd = Date.newInstance(2025,1,12);  // Sunday
+        cnt = ScheduleHoursDistributor.countUsableWorkdays(cStart, cEnd, new Set<Date>(), 6);
+        System.assertEquals(6, cnt, '6-day schedule should count Mon-Sat as usable days');
+
+        // Explicit workday patterns: 7-day should include whole week
+        cnt = ScheduleHoursDistributor.countUsableWorkdays(cStart, cEnd, new Set<Date>(), 7);
+        System.assertEquals(7, cnt, '7-day schedule should count Mon-Sun as usable days');
+
+        // Explicit workday patterns: 3-day should count Mon-Wed only
+        cnt = ScheduleHoursDistributor.countUsableWorkdays(cStart, cEnd, new Set<Date>(), 3);
+        System.assertEquals(3, cnt, '3-day schedule should count Mon-Wed as usable days');
+
+        // Exclusions still apply in weekend-enabled mode
+        Set<Date> exclWeekendEnabled = new Set<Date>{ Date.newInstance(2025,1,11) }; // Sunday
+        cnt = ScheduleHoursDistributor.countUsableWorkdays(cStart, cEnd, exclWeekendEnabled, 7);
+        System.assertEquals(6, cnt, 'Excluded dates should be removed even in 7-day mode');
     }
 
     @isTest


### PR DESCRIPTION
The countUsableWorkdays method now supports configurable workday patterns, allowing for more flexible counting of usable days. Unit tests have been added to validate various scenarios, and the README has been updated for clarity.

Fixes #56