### PR TITLE
Refactor workdays handling with input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The overall goal is to replace manual schedule exception entry with consistent, 
 
 2. **Input Validation**
    - Validates required fields such as schedule dates, total hours, workdays, category weeks, and percentages.
+   - `numberOfWorkDays` is bounded to the supported range `1..7` before allocation and exception-field population.
    - Ensures onsite dates (if provided) are valid and complete.
 
 3. **Holiday Processing**
@@ -89,7 +90,7 @@ The `ScheduleInput` class provides all parameters required for processing.
 - `startDate`
 - `endDate`
 - `numberOfHours`
-- `numberOfWorkDays` — number of working days per week (e.g., `5` for Mon–Fri, `7` for all days)
+- `numberOfWorkDays` — number of working days per week. Values are bounded to `1..7` (e.g., `5` for Mon–Fri, `7` for all days).
 
 ### Category Configuration
 - `cat1Weeks`, `cat2Weeks`, `cat3Weeks`, `postWeeks`
@@ -138,6 +139,7 @@ The method returns one wrapper per input containing:
 
 - Hours are assigned to the first `numberOfWorkDays` days of each week (for example: `5 = Mon–Fri`, `7 = Mon–Sun`)
 - Usable-day counting uses the same `numberOfWorkDays` pattern as hour assignment
+- Out-of-range `numberOfWorkDays` inputs are consistently bounded to `1..7` across both day counting and schedule-exception day fields
 - Holidays and onsite gap days are **always excluded**
 - Category percentages are **normalized** so valid categories total **100%**
 - Capacity is calculated per category as `usableDays × 24`
@@ -173,7 +175,7 @@ The following helper methods are `public` and can be called directly in unit tes
 Extracts all individual dates covered by a list of schedule exceptions (used to identify holiday dates). Handles single-day and multi-day exceptions, as well as `null` entries in the list.
 
 ### `createScheduleException(Id scheduleId, Date startDate, Date endDate, Integer workDays, Decimal hoursPerDay)`
-Creates and returns a single `pse__Schedule_Exception__c` record with per-day hours populated based on the `workDays` count (1 = Mon only, 5 = Mon–Fri, 7 = all days).
+Creates and returns a single `pse__Schedule_Exception__c` record with per-day hours populated based on the `workDays` count. `workDays` is bounded to `1..7` (1 = Mon only, 5 = Mon–Fri, 7 = all days).
 
 ### `addSplitExceptions(Date segStart, Date segEnd, Decimal hoursPerDay, Integer workDays, Id scheduleId, Date inputStart, Date inputEnd, Set<Date> allSplits, List<pse__Schedule_Exception__c> allExceptions, List<pse__Schedule_Exception__c> catList)`
 Iterates a date range and splits it into contiguous segments at every holiday and onsite gap date. Each uninterrupted segment is created as a separate `pse__Schedule_Exception__c` record added to both `allExceptions` and `catList`.
@@ -218,6 +220,7 @@ The test class `ScheduleHoursDistributorTest` provides comprehensive coverage fo
 | `testExistingMultiDayExceptionExcludesHolidayDates` | No generated exception overlaps a multi-day holiday range |
 | `testOnsiteGapWeekIsSevenDaysZeroHours` | Onsite gap week is exactly 7 days with all-zero hours |
 | `testGetNormalizedDayOfWeek_MondayIsOne` | Runtime normalization always maps Monday to 1 and Sunday to 7 |
+| `testNumberOfWorkDaysOutOfRange_IsConsistentEverywhere` | Out-of-range `numberOfWorkDays` values are bounded consistently for usable-day counting and exception day-field population |
 | `testPercentSumLessAndGreaterThan100` | Percentages summing to < 100 or > 100 are normalized correctly |
 | `testMathWithoutExistingExceptions_TotalHoursMatch` | Scheduled hours do not exceed requested hours |
 | `testMathWithExistingHolidayExcludesDate_TotalHoursMatch` | Holiday dates are excluded and scheduled hours do not exceed requested hours |

--- a/force-app/main/default/classes/ScheduleHoursDistributor.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributor.cls
@@ -32,6 +32,7 @@ public with sharing class ScheduleHoursDistributor {
         if (input.startDate > input.endDate) return createErrorWrapper('Error: Start Date must be on or before End Date.');
         if (input.numberOfHours == null) return createErrorWrapper('Error: Number of Hours cannot be null.');
         if (input.numberOfWorkDays == null) return createErrorWrapper('Error: Number of Work Days cannot be null.');
+        Integer boundedWorkDays = boundWorkDays(input.numberOfWorkDays);
         if (input.cat1Weeks == null || input.cat2Weeks == null || input.cat3Weeks == null || input.postWeeks == null)
             return createErrorWrapper('Error: Week values cannot be null.');
         if (input.cat1Percentage == null || input.cat2Percentage == null || input.cat3Percentage == null || input.postPercentage == null)
@@ -162,7 +163,7 @@ public with sharing class ScheduleHoursDistributor {
             Date onsiteSegmentEnd = (onsiteGapWeekEnd > input.endDate) ? input.endDate : onsiteGapWeekEnd;
             if (onsiteSegmentStart <= onsiteSegmentEnd) {
                 addSplitExceptions(
-                    onsiteSegmentStart, onsiteSegmentEnd, 0, input.numberOfWorkDays, input.scheduleId,
+                    onsiteSegmentStart, onsiteSegmentEnd, 0, boundedWorkDays, input.scheduleId,
                     input.startDate, input.endDate, holidayDates, allExceptions, new List<pse__Schedule_Exception__c>()
                 );
             }
@@ -180,13 +181,13 @@ public with sharing class ScheduleHoursDistributor {
         };
 
         Integer cat1UsableDays = (cat1Valid && cat1ActualStart != null && cat1ActualEnd != null && cat1ActualStart <= cat1ActualEnd)
-            ? countUsableWorkdays(cat1ActualStart, cat1ActualEnd, allSplits, input.numberOfWorkDays) : 0;
+            ? countUsableWorkdays(cat1ActualStart, cat1ActualEnd, allSplits, boundedWorkDays) : 0;
         Integer cat2UsableDays = (cat2Valid && cat2ActualStart != null && cat2ActualEnd != null && cat2ActualStart <= cat2ActualEnd)
-            ? countUsableWorkdays(cat2ActualStart, cat2ActualEnd, allSplits, input.numberOfWorkDays) : 0;
+            ? countUsableWorkdays(cat2ActualStart, cat2ActualEnd, allSplits, boundedWorkDays) : 0;
         Integer cat3UsableDays = (cat3Valid && cat3ActualStart != null && cat3ActualEnd != null && cat3ActualStart <= cat3ActualEnd)
-            ? countUsableWorkdays(cat3ActualStart, cat3ActualEnd, allSplits, input.numberOfWorkDays) : 0;
+            ? countUsableWorkdays(cat3ActualStart, cat3ActualEnd, allSplits, boundedWorkDays) : 0;
         Integer postUsableDays = (postValid && postActualStart != null && postActualEnd != null && postActualStart <= postActualEnd)
-            ? countUsableWorkdays(postActualStart, postActualEnd, allSplits, input.numberOfWorkDays) : 0;
+            ? countUsableWorkdays(postActualStart, postActualEnd, allSplits, boundedWorkDays) : 0;
 
         Map<String, Decimal> hoursPerDayMap = new Map<String, Decimal>{'cat1' => 0, 'cat2' => 0, 'cat3' => 0, 'post' => 0};
         List<String> usableCats = new List<String>();
@@ -288,16 +289,16 @@ public with sharing class ScheduleHoursDistributor {
         }
 
         if (cat1Valid && cat1ActualStart != null && cat1ActualEnd != null && cat1ActualStart <= cat1ActualEnd) {
-            ScheduleHoursDistributor.addSplitExceptions(cat1ActualStart, cat1ActualEnd, cat1HoursPerDay, input.numberOfWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat1'));
+            ScheduleHoursDistributor.addSplitExceptions(cat1ActualStart, cat1ActualEnd, cat1HoursPerDay, boundedWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat1'));
         }
         if (cat2Valid && cat2ActualStart != null && cat2ActualEnd != null && cat2ActualStart <= cat2ActualEnd) {
-            ScheduleHoursDistributor.addSplitExceptions(cat2ActualStart, cat2ActualEnd, cat2HoursPerDay, input.numberOfWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat2'));
+            ScheduleHoursDistributor.addSplitExceptions(cat2ActualStart, cat2ActualEnd, cat2HoursPerDay, boundedWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat2'));
         }
         if (cat3Valid && cat3ActualStart != null && cat3ActualEnd != null && cat3ActualStart <= cat3ActualEnd) {
-            ScheduleHoursDistributor.addSplitExceptions(cat3ActualStart, cat3ActualEnd, cat3HoursPerDay, input.numberOfWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat3'));
+            ScheduleHoursDistributor.addSplitExceptions(cat3ActualStart, cat3ActualEnd, cat3HoursPerDay, boundedWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('cat3'));
         }
         if (postValid && postActualStart != null && postActualEnd != null && postActualStart <= postActualEnd) {
-            ScheduleHoursDistributor.addSplitExceptions(postActualStart, postActualEnd, postHoursPerDay, input.numberOfWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('post'));
+            ScheduleHoursDistributor.addSplitExceptions(postActualStart, postActualEnd, postHoursPerDay, boundedWorkDays, input.scheduleId, input.startDate, input.endDate, allSplits, allExceptions, catExceptions.get('post'));
         }
 
         return new ScheduleExceptionOutputWrapper(allExceptions, null);
@@ -326,17 +327,18 @@ public with sharing class ScheduleHoursDistributor {
 
     // Helper: Creates and returns a single schedule exception record
     public static pse__Schedule_Exception__c createScheduleException(Id scheduleId, Date startDate, Date endDate, Integer workDays, Decimal hoursPerDay) {
+        Integer boundedWorkDays = boundWorkDays(workDays);
         return new pse__Schedule_Exception__c(
             pse__Schedule__c = scheduleId,
             pse__Date__c = startDate,
             pse__End_Date__c = endDate,
-            pse__Monday_Hours__c = (workDays >= 1) ? hoursPerDay : 0,
-            pse__Tuesday_Hours__c = (workDays >= 2) ? hoursPerDay : 0,
-            pse__Wednesday_Hours__c = (workDays >= 3) ? hoursPerDay : 0,
-            pse__Thursday_Hours__c = (workDays >= 4) ? hoursPerDay : 0,
-            pse__Friday_Hours__c = (workDays >= 5) ? hoursPerDay : 0,
-            pse__Saturday_Hours__c = (workDays >= 6) ? hoursPerDay : 0,
-            pse__Sunday_Hours__c = (workDays >= 7) ? hoursPerDay : 0
+            pse__Monday_Hours__c = (boundedWorkDays >= 1) ? hoursPerDay : 0,
+            pse__Tuesday_Hours__c = (boundedWorkDays >= 2) ? hoursPerDay : 0,
+            pse__Wednesday_Hours__c = (boundedWorkDays >= 3) ? hoursPerDay : 0,
+            pse__Thursday_Hours__c = (boundedWorkDays >= 4) ? hoursPerDay : 0,
+            pse__Friday_Hours__c = (boundedWorkDays >= 5) ? hoursPerDay : 0,
+            pse__Saturday_Hours__c = (boundedWorkDays >= 6) ? hoursPerDay : 0,
+            pse__Sunday_Hours__c = (boundedWorkDays >= 7) ? hoursPerDay : 0
         );
     }
 
@@ -373,9 +375,7 @@ public with sharing class ScheduleHoursDistributor {
     // Helper: Counts usable workdays between two dates, excluding holidays and onsite gap days.
     // Workday pattern follows numberOfWorkDays: 1=Mon only ... 5=Mon-Fri, 6=Mon-Sat, 7=Mon-Sun.
     public static Integer countUsableWorkdays(Date start, Date endDate, Set<Date> excludeDates, Integer numberOfWorkDays) {
-        Integer boundedWorkDays = numberOfWorkDays == null ? 5 : numberOfWorkDays;
-        if (boundedWorkDays < 1) boundedWorkDays = 1;
-        if (boundedWorkDays > 7) boundedWorkDays = 7;
+        Integer boundedWorkDays = boundWorkDays(numberOfWorkDays);
 
         Integer count = 0;
         for (Date d = start; d <= endDate; d = d.addDays(1)) {
@@ -415,11 +415,17 @@ public with sharing class ScheduleHoursDistributor {
 
     // Helper: Returns true if date is one of the configured workdays for the week.
     public static Boolean isScheduledWorkday(Date d, Integer numberOfWorkDays) {
+        Integer boundedWorkDays = boundWorkDays(numberOfWorkDays);
+        Integer dow = getNormalizedDayOfWeek(d); // 1=Monday, 7=Sunday
+        return dow >= 1 && dow <= boundedWorkDays;
+    }
+
+    // Helper: Clamps workdays to supported range [1..7], defaulting to 5 when null.
+    private static Integer boundWorkDays(Integer numberOfWorkDays) {
         Integer boundedWorkDays = numberOfWorkDays == null ? 5 : numberOfWorkDays;
         if (boundedWorkDays < 1) boundedWorkDays = 1;
         if (boundedWorkDays > 7) boundedWorkDays = 7;
-        Integer dow = getNormalizedDayOfWeek(d); // 1=Monday, 7=Sunday
-        return dow >= 1 && dow <= boundedWorkDays;
+        return boundedWorkDays;
     }
 
     // Helper: Returns true if the date is a weekday (Mon-Fri)

--- a/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
+++ b/force-app/main/default/classes/ScheduleHoursDistributorTest.cls
@@ -839,4 +839,26 @@ public class ScheduleHoursDistributorTest {
         System.assert(totalHours <= 120, 'Five-day range should cap total at 120 hours');
         System.assert(totalHours < input.numberOfHours, 'Unschedulable overflow should be dropped');
     }
+
+    @isTest
+    static void testNumberOfWorkDaysOutOfRange_IsConsistentEverywhere() {
+        Date weekStart = Date.newInstance(2025, 1, 6); // Monday
+        Date weekEnd = Date.newInstance(2025, 1, 12);  // Sunday
+
+        // Low out-of-range value should clamp to 1 (Monday only).
+        Integer usableLow = ScheduleHoursDistributor.countUsableWorkdays(weekStart, weekEnd, new Set<Date>(), 0);
+        System.assertEquals(1, usableLow, 'numberOfWorkDays=0 should clamp to 1 usable day');
+        pse__Schedule_Exception__c excLow = ScheduleHoursDistributor.createScheduleException(null, weekStart, weekEnd, 0, 8);
+        System.assertEquals(8, excLow.pse__Monday_Hours__c, 'Clamped low value should populate Monday hours');
+        System.assertEquals(0, excLow.pse__Tuesday_Hours__c, 'Clamped low value should not populate Tuesday hours');
+        System.assertEquals(0, excLow.pse__Sunday_Hours__c, 'Clamped low value should not populate Sunday hours');
+
+        // High out-of-range value should clamp to 7 (all days).
+        Integer usableHigh = ScheduleHoursDistributor.countUsableWorkdays(weekStart, weekEnd, new Set<Date>(), 9);
+        System.assertEquals(7, usableHigh, 'numberOfWorkDays=9 should clamp to 7 usable days');
+        pse__Schedule_Exception__c excHigh = ScheduleHoursDistributor.createScheduleException(null, weekStart, weekEnd, 9, 8);
+        System.assertEquals(8, excHigh.pse__Monday_Hours__c, 'Clamped high value should populate Monday hours');
+        System.assertEquals(8, excHigh.pse__Tuesday_Hours__c, 'Clamped high value should populate Tuesday hours');
+        System.assertEquals(8, excHigh.pse__Sunday_Hours__c, 'Clamped high value should populate Sunday hours');
+    }
 }


### PR DESCRIPTION
Refactor the handling of workdays to ensure values are bounded between 1 and 7 during schedule exception processing. Add tests to verify clamping behavior for out-of-range inputs. Update documentation to reflect these changes.

Fixes #62